### PR TITLE
Factor out execute() changes into a separate method

### DIFF
--- a/src/main/java/org/plumelib/bcelutil/StackVer.java
+++ b/src/main/java/org/plumelib/bcelutil/StackVer.java
@@ -70,7 +70,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
  * information is to be found at the do_verify() method's documentation.
  *
  * @version $Id$
- * @see #do_stack_ver()
+ * @see #do_stack_ver
  */
 @SuppressWarnings({"rawtypes", "nullness", "interning"}) // third-party code
 public final class StackVer {

--- a/src/main/java/org/plumelib/bcelutil/package-info.java
+++ b/src/main/java/org/plumelib/bcelutil/package-info.java
@@ -10,7 +10,7 @@
  * @see org.plumelib.bcelutil.BcelUtil BcelUtil for notes on inspecting a Java class file
  * @see org.plumelib.bcelutil.InstructionListUtils InstructionListUtils for notes on modifing a Java
  *     class file
- * @see the <a href="https://commons.apache.org/proper/commons-bcel/index.html">Commons BCEL</a> web
- *     site for details about the BCEL library
+ * @see <a href="https://commons.apache.org/proper/commons-bcel/index.html">Commons BCEL web site
+ *     for details about the BCEL library</a>
  */
 package org.plumelib.bcelutil;


### PR DESCRIPTION
This reduces the size of the diffs against upstream.