### PR TITLE
Add -AsuppressWarnings=type.checking.not.run

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,8 @@ checkerFramework {
     '-AcheckPurityAnnotations',
     '-ArequirePrefixInWarningSuppressions',
     '-AwarnUnneededSuppressions',
+    // This is a hack to work around the fact that WPI (whole-program inference)
+    // yields a set of annotations that do not type-check cleanly.
     '-AsuppressWarnings=type.checking.not.run',
   ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ checkerFramework {
     '-AcheckPurityAnnotations',
     '-ArequirePrefixInWarningSuppressions',
     '-AwarnUnneededSuppressions',
+    '-AsuppressWarnings=type.checking.not.run',
   ]
 }
 


### PR DESCRIPTION
This is to fix the errors in https://github.com/typetools/checker-framework/pull/4352 and needs to be merged so that tests there pass.