### PR TITLE
Upgrade to Gradle 7.0

### DIFF
--- a/gradle/mavencentral.gradle
+++ b/gradle/mavencentral.gradle
@@ -21,21 +21,12 @@
 /// Maven Central publishing
 /// (From http://central.sonatype.org/pages/gradle.html )
 
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-group = "org.plumelib"
-archivesBaseName = "bcel-util"
-version = "1.1.12"
-
-task javadocJar(type: Jar) {
-    classifier = 'javadoc'
-    from javadoc
-}
-
-task sourcesJar(type: Jar) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 artifacts {
@@ -47,58 +38,58 @@ signing {
     sign configurations.archives
 }
 
-uploadArchives {
-  doFirst {
-    repositories {
-      mavenDeployer {
-        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+publishing {
+  publications {
+    maven(MavenPublication) {
+      groupId = 'org.plumelib'
+      artifactId = 'bcel-util'
+      version = '1.1.12'
 
-        repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-          authentication(userName: ossrhUsername, password: ossrhPassword)
+      from components.java
+      artifact sourcesJar
+      artifact javadocJar
+      pom {
+        name = 'Plume-lib Bcel-Util'
+        description = 'Utility functions for BCEL.'
+        url = 'https://github.com/plume-lib/bcel-util'
+
+        scm {
+          connection = 'scm:git:git@github.com:plume-lib/bcel-util.git'
+          developerConnection = 'scm:git:git@github.com:plume-lib/bcel-util.git'
+          url = 'git@github.com:plume-lib/bcel-util.git'
         }
 
-        snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-          authentication(userName: ossrhUsername, password: ossrhPassword)
+        licenses {
+          license {
+            name = 'MIT License'
+            url = 'https://opensource.org/licenses/MIT'
+          }
         }
 
-        pom.project {
-          name 'Plume-lib Bcel-Util'
-          packaging 'jar'
-          description 'Utility functions for BCEL.'
-          url 'https://github.com/plume-lib/bcel-util'
-
-          scm {
-            connection 'scm:git:git@github.com:plume-lib/bcel-util.git'
-            developerConnection 'scm:git:git@github.com:plume-lib/bcel-util.git'
-            url 'git@github.com:plume-lib/bcel-util.git'
-          }
-
-          licenses {
-            license {
-              name 'MIT License'
-              url 'https://opensource.org/licenses/MIT'
-            }
-          }
-
-          developers {
-            developer {
-              id 'mernst'
-              name 'Michael Ernst'
-              email 'mernst@alum.mit.edu'
-            }
+        developers {
+          developer {
+            id = 'mernst'
+            name = 'Michael Ernst'
+            email = 'mernst@alum.mit.edu'
           }
         }
       }
     }
   }
+  repositories {
+    maven {
+      url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+      credentials {
+        username = ossrhUsername
+        password = ossrhPassword
+      }
+    }
+    maven {
+      url = "https://oss.sonatype.org/content/repositories/snapshots/"
+      credentials {
+        username = ossrhUsername
+        password = ossrhPassword
+      }
+    }
+  }
 }
-
-// The *-all.jar file isn't used by Maven/Gradle users.  The point of publishing
-// it is to host all artifacts on Maven Central, for people who want *-all.jar.
-// publishing  {
-//   publications {
-//     shadow(MavenPublication) {
-//       from components.shadow
-//       artifactId = 'bcel-util-all'
-//   }
-// }

--- a/gradle/mavencentral.gradle
+++ b/gradle/mavencentral.gradle
@@ -8,10 +8,9 @@
 //  * git pull
 //  * Update the version number in ../README.md and in this file (multiple times in each).
 //  * Update ../CHANGELOG.md .
-//  * Save files.
-//  * Run in the top-level directory:  ./gradlew clean javadocWeb && ./gradlew clean uploadArchives
+//  * Save files and stage changes.
+//  * Run in the top-level directory:  ./gradlew clean publish && ./gradlew javadocWeb
 //  * Browse to https://oss.sonatype.org/#stagingRepositories, complete the Maven Central release.
-//  * Stage changes.
 //  * Add a git tag:
 //    VER=1.1.12 && git commit -m "Version $VER" && git push && git tag -a v$VER -m "Version $VER" && git push && git push --tags
 //  * Make a GitHub release. Go to the GitHub releases page, make a release, call it "bcel-util 1.1.12", use the text from ../CHANGELOG.md as the description, attach the .jar file from ../build/libs/
@@ -31,11 +30,6 @@ java {
 
 artifacts {
     archives javadocJar, sourcesJar
-}
-
-signing {
-    required { project.gradle.taskGraph.hasTask("uploadArchives") }
-    sign configurations.archives
 }
 
 publishing {
@@ -80,16 +74,21 @@ publishing {
     maven {
       url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
       credentials {
-        username = ossrhUsername
-        password = ossrhPassword
+        username = project.properties.get('ossrhUsername')
+        password = project.properties.get('ossrhPassword')
       }
     }
     maven {
       url = "https://oss.sonatype.org/content/repositories/snapshots/"
       credentials {
-        username = ossrhUsername
-        password = ossrhPassword
+        username = project.properties.get('ossrhUsername')
+        password = project.properties.get('ossrhPassword')
       }
     }
   }
+}
+
+signing {
+    required { project.gradle.taskGraph.hasTask("uploadArchives") }
+    sign configurations.archives
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This updates the library to use Gradle 7.0 as part of solving an issue with building on JDK 16 (where Gradle is complaining of an unsupported major class version because bcel-util's gradle is trying to read something built with the main checker-framework.

The actual upgrade is one line, but publishing with the maven plugin is no longer supported (it was already deprecated but now it's just plain removed), so it requires upgrading to the newer maven-publish plugin.  I've made my best attempt using guides but I haven't actually tested publishing to sonatype as I don't have any credentials for it.  You may want to pull and test before merging in.