### PR TITLE
Test under JDK 25

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '17', '21', '24' ]
+        java: [ '17', '21', '24', '25-ea' ]
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,6 +21,8 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
+        check-latest: true
+        cache: 'gradle'
     - name: ./gradlew build javadoc
       run: ./gradlew build
     - name: ./gradlew requireJavadoc

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,9 @@ spotless {
   }
   java {
     targetExclude('**/WeakIdentityHashMap.java')
-    googleJavaFormat()
+    // googleJavaFormat()
+    // Version number required for Java 25.
+    googleJavaFormat('1.28.0')
     formatAnnotations()
   }
   groovyGradle {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI matrix expanded to run against Java 25-ea in addition to 17, 21, and 24.
  * CI JDK setup now checks for the latest installer and enables Gradle caching for faster builds.

* **Style**
  * Java formatter pinned to a specific Google Java Format version (1.28.0) to ensure consistent formatting across Java versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->